### PR TITLE
Bugfix for /warp when player don't use full warp name

### DIFF
--- a/src/main/kotlin/me/marylieh/simplewarp/commands/WarpCommandExecutor.kt
+++ b/src/main/kotlin/me/marylieh/simplewarp/commands/WarpCommandExecutor.kt
@@ -21,14 +21,12 @@ class WarpCommandExecutor : CommandExecutor {
         if (player.hasPermission("simplewarp.warp")) {
             if (args.size == 1) {
 
-                var id = args[0]
+                var id ="";
                 if (player.hasPermission("simplewarp.warps")) {
                     val filtered = Config.getConfig().getConfigurationSection(".Warps")?.getKeys(false)?.filter{value -> value.lowercase().startsWith(args[0].lowercase())}
-                    if(filtered?.size != 1){
-                        player.sendMessage("${SimpleWarp.instance.prefix} §cThis warp didn't exists!")
-                        return true
-                    } else {id = filtered[0]}
-                }
+                    if(filtered?.size == 1){id = filtered[0]}
+                } 
+                if(id==""){id = args[0]}
                 if (Config.getConfig().getString(".Warps.$id") == null) {
                     player.sendMessage("${SimpleWarp.instance.prefix} §cThis warp didn't exists!")
                     return true


### PR DESCRIPTION
When player use /warp my and exist warps is ["my","myPlace"] command send back to player uncorrect information about that /my warp does not exist.
Additionally message about warp is handling only for line 31.

var id = ""; is correctly becouse line 22 if (args.size == 1) check if arg[0] exist.